### PR TITLE
Fix passing glue string after array is deprecated

### DIFF
--- a/src/io/Google_REST.php
+++ b/src/io/Google_REST.php
@@ -120,7 +120,7 @@ class Google_REST {
     $requestUrl = str_replace('%40', '@', $requestUrl);
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;


### PR DESCRIPTION
Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters